### PR TITLE
refactor: rename noInteractive flag to nonInteractive across the code…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist
-package-lock.json
+pnpm-lock.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,5 @@
     "**/dist": true,
     "**/pnpm-lock.yaml": true
   },
-  "cSpell.words": ["AADSTS"]
+  "cSpell.words": ["AADSTS", "azpim"]
 }

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Use flags to activate or deactivate PIM roles directly without going through the
 
 ```bash
 # Activate a single role by name (non-interactive)
-azp activate --no-interactive --yes \
+azp activate --non-interactive --yes \
    --subscription-id <SUBSCRIPTION_GUID> \
    --role-name "Owner" \
    --duration-hours 2 \
@@ -150,20 +150,20 @@ azp activate --no-interactive --yes \
    --output json
 
 # Activate multiple roles (repeat --role-name)
-azp activate --no-interactive --yes \
+azp activate --non-interactive --yes \
    --subscription-id <SUBSCRIPTION_GUID> \
    --role-name "Contributor" \
    --role-name "User Access Administrator"
 
 # If a role name matches multiple eligible roles (different scopes),
-# --no-interactive will error unless you explicitly allow activating all matches
-azp activate --no-interactive --yes \
+# --non-interactive will error unless you explicitly allow activating all matches
+azp activate --non-interactive --yes \
    --subscription-id <SUBSCRIPTION_GUID> \
    --role-name "Contributor" \
    --allow-multiple
 
 # Preview what would happen without submitting requests
-azp activate --no-interactive --dry-run \
+azp activate --non-interactive --dry-run \
    --subscription-id <SUBSCRIPTION_GUID> \
    --role-name "Contributor" \
    --output json
@@ -173,13 +173,13 @@ azp activate --no-interactive --dry-run \
 
 ```bash
 # Deactivate specific roles
-azp deactivate --no-interactive --yes \
+azp deactivate --non-interactive --yes \
    --subscription-id <SUBSCRIPTION_GUID> \
    --role-name "Owner" \
    --justification "Task completed"
 
 # Deactivate across all subscriptions (omit subscription-id)
-azp deactivate --no-interactive --yes \
+azp deactivate --non-interactive --yes \
    --role-name "Contributor" \
    --allow-multiple
 ```
@@ -188,7 +188,7 @@ azp deactivate --no-interactive --yes \
 
 **Common flags (activate/deactivate):**
 
-- `--no-interactive` - Disable interactive prompts
+- `--non-interactive` - Disable interactive prompts
 - `-y, --yes` - Skip confirmation prompts
 - `--subscription-id <id>` - Target subscription (optional for deactivate)
 - `--role-name <name>` - Role name(s) to target (can be repeated)
@@ -259,10 +259,10 @@ azp preset remove daily-ops
 azp activate --preset daily-ops --yes
 
 # Non-interactive run using the preset
-azp activate --preset daily-ops --no-interactive --yes --output json
+azp activate --preset daily-ops --non-interactive --yes --output json
 
 # Deactivate using a preset
-azp deactivate --preset daily-ops --no-interactive --yes
+azp deactivate --preset daily-ops --non-interactive --yes
 ```
 
 ### Defaults
@@ -270,7 +270,7 @@ azp deactivate --preset daily-ops --no-interactive --yes
 When you create a preset via `azp preset add`, you can optionally set it as the default for `activate` and/or `deactivate`.
 
 - Default presets are applied automatically when you run one-shot flows and you haven’t explicitly provided the required flags.
-- Example: after setting a default activate preset, `azp activate --no-interactive --yes` can work without specifying `--subscription-id`/`--role-name`.
+- Example: after setting a default activate preset, `azp activate --non-interactive --yes` can work without specifying `--subscription-id`/`--role-name`.
 
 ### Example Session
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Terminal app to manage Azure PIM role activations",
   "main": "dist/index.js",
   "bin": {
-    "azp": "./dist/index.js"
+    "azp": "./dist/index.js",
+    "azpim": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -39,14 +40,14 @@
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",
-    "inquirer": "^13.1.0",
+    "inquirer": "^13.2.0",
     "isomorphic-fetch": "^3.0.0",
     "ora": "^9.0.0",
     "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.9",
-    "@types/node": "^25.0.6",
+    "@types/node": "^25.0.9",
     "esbuild": "^0.27.2",
     "standard-version": "^9.5.0",
     "ts-node": "^10.9.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ export type ActivateOnceOptions = {
   durationHours?: number;
   justification?: string;
   dryRun?: boolean;
-  noInteractive?: boolean;
+  nonInteractive?: boolean;
   yes?: boolean;
   allowMultiple?: boolean;
 };
@@ -65,7 +65,7 @@ export type DeactivateOnceOptions = {
   roleNames: string[];
   justification?: string;
   dryRun?: boolean;
-  noInteractive?: boolean;
+  nonInteractive?: boolean;
   yes?: boolean;
   allowMultiple?: boolean;
 };
@@ -115,8 +115,8 @@ export const activateOnce = async (authContext: AuthContext, options: ActivateOn
     throw new Error("Missing required flag: --role-name (can be repeated)");
   }
 
-  if (options.noInteractive && !options.yes && !options.dryRun) {
-    throw new Error("--no-interactive requires --yes (or use --dry-run)");
+  if (options.nonInteractive && !options.yes && !options.dryRun) {
+    throw new Error("--non-interactive requires --yes (or use --dry-run)");
   }
 
   logBlank();
@@ -154,9 +154,9 @@ export const activateOnce = async (authContext: AuthContext, options: ActivateOn
     }
 
     if (matches.length > 1 && !options.allowMultiple) {
-      if (options.noInteractive) {
+      if (options.nonInteractive) {
         throw new Error(
-          `Ambiguous --role-name="${name}" matched ${matches.length} eligible roles. Use --allow-multiple to activate all matches, or run without --no-interactive to select interactively.`
+          `Ambiguous --role-name="${name}" matched ${matches.length} eligible roles. Use --allow-multiple to activate all matches, or run without --non-interactive to select interactively.`
         );
       }
 
@@ -336,8 +336,8 @@ export const deactivateOnce = async (authContext: AuthContext, options: Deactiva
     throw new Error("Missing required flag: --role-name (can be repeated)");
   }
 
-  if (options.noInteractive && !options.yes && !options.dryRun) {
-    throw new Error("--no-interactive requires --yes (or use --dry-run)");
+  if (options.nonInteractive && !options.yes && !options.dryRun) {
+    throw new Error("--non-interactive requires --yes (or use --dry-run)");
   }
 
   logBlank();
@@ -393,9 +393,9 @@ export const deactivateOnce = async (authContext: AuthContext, options: Deactiva
     }
 
     if (matches.length > 1 && !options.allowMultiple) {
-      if (options.noInteractive) {
+      if (options.nonInteractive) {
         throw new Error(
-          `Ambiguous --role-name="${name}" matched ${matches.length} active roles. Use --allow-multiple to deactivate all matches, or run without --no-interactive to select interactively.`
+          `Ambiguous --role-name="${name}" matched ${matches.length} active roles. Use --allow-multiple to deactivate all matches, or run without --non-interactive to select interactively.`
         );
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ type ActivateCommandOptions = {
   durationHours?: number;
   justification?: string;
   preset?: string;
-  noInteractive?: boolean;
+  nonInteractive?: boolean;
   yes?: boolean;
   allowMultiple?: boolean;
   dryRun?: boolean;
@@ -43,7 +43,7 @@ type DeactivateCommandOptions = {
   roleName?: string[];
   justification?: string;
   preset?: string;
-  noInteractive?: boolean;
+  nonInteractive?: boolean;
   yes?: boolean;
   allowMultiple?: boolean;
   dryRun?: boolean;
@@ -107,7 +107,7 @@ program
   .option("--subscription-id <id>", "Azure subscription ID (required for non-interactive one-shot activation)")
   .option(
     "--role-name <name>",
-    "Role name to activate (can be repeated). In --no-interactive mode, ambiguous matches error unless --allow-multiple is set.",
+    "Role name to activate (can be repeated). In --non-interactive mode, ambiguous matches error unless --allow-multiple is set.",
     (value: string, previous: string[] | undefined) => {
       const list = previous ?? [];
       list.push(value);
@@ -118,7 +118,7 @@ program
   .option("--duration-hours <n>", "Duration hours (1-8)", (value: string) => Number.parseInt(value, 10))
   .option("--justification <text>", "Justification for activation")
   .option("--preset <name>", "Use a saved preset (fills defaults; flags still override)")
-  .option("--no-interactive", "Do not prompt; require flags to be unambiguous")
+  .option("--non-interactive", "Do not prompt; require flags to be unambiguous")
   .option("-y, --yes", "Skip confirmation prompt")
   .option("--allow-multiple", "Allow activating multiple eligible matches for a role name")
   .option("--dry-run", "Resolve targets and print summary without submitting activation requests")
@@ -138,7 +138,7 @@ program
       const explicitPresetName = getOptionValueSource(command, "preset") === "cli" ? cmd.preset : undefined;
 
       const requestedRoleNames = cmd.roleName ?? [];
-      const wantsOneShot = Boolean(cmd.noInteractive || cmd.subscriptionId || requestedRoleNames.length > 0 || cmd.dryRun || explicitPresetName);
+      const wantsOneShot = Boolean(cmd.nonInteractive || cmd.subscriptionId || requestedRoleNames.length > 0 || cmd.dryRun || explicitPresetName);
 
       // Authenticate (required for both interactive and one-shot flows)
       const authContext = await authenticate();
@@ -190,7 +190,7 @@ program
         durationHours: effectiveDurationHours,
         justification: effectiveJustification,
         dryRun: cmd.dryRun,
-        noInteractive: cmd.noInteractive,
+        nonInteractive: cmd.nonInteractive,
         yes: cmd.yes,
         allowMultiple: effectiveAllowMultiple,
       });
@@ -233,7 +233,7 @@ program
   .option("--subscription-id <id>", "Azure subscription ID (optional; if omitted, searches all subscriptions)")
   .option(
     "--role-name <name>",
-    "Role name to deactivate (can be repeated). In --no-interactive mode, ambiguous matches error unless --allow-multiple is set.",
+    "Role name to deactivate (can be repeated). In --non-interactive mode, ambiguous matches error unless --allow-multiple is set.",
     (value: string, previous: string[] | undefined) => {
       const list = previous ?? [];
       list.push(value);
@@ -243,7 +243,7 @@ program
   )
   .option("--justification <text>", "Justification for deactivation")
   .option("--preset <name>", "Use a saved preset (fills defaults; flags still override)")
-  .option("--no-interactive", "Do not prompt; require flags to be unambiguous")
+  .option("--non-interactive", "Do not prompt; require flags to be unambiguous")
   .option("-y, --yes", "Skip confirmation prompt")
   .option("--allow-multiple", "Allow deactivating multiple active matches for a role name")
   .option("--dry-run", "Resolve targets and print summary without submitting deactivation requests")
@@ -263,7 +263,7 @@ program
       const explicitPresetName = getOptionValueSource(command, "preset") === "cli" ? cmd.preset : undefined;
 
       const requestedRoleNames = cmd.roleName ?? [];
-      const wantsOneShot = Boolean(cmd.noInteractive || cmd.subscriptionId || requestedRoleNames.length > 0 || cmd.dryRun || explicitPresetName);
+      const wantsOneShot = Boolean(cmd.nonInteractive || cmd.subscriptionId || requestedRoleNames.length > 0 || cmd.dryRun || explicitPresetName);
 
       // Authenticate (required for both interactive and one-shot flows)
       const authContext = await authenticate();
@@ -311,7 +311,7 @@ program
         roleNames: effectiveRoleNames,
         justification: effectiveJustification,
         dryRun: cmd.dryRun,
-        noInteractive: cmd.noInteractive,
+        nonInteractive: cmd.nonInteractive,
         yes: cmd.yes,
         allowMultiple: effectiveAllowMultiple,
       });


### PR DESCRIPTION
…base

- Updated all instances of the `noInteractive` flag to `nonInteractive` in CLI options, command options, and related logic.
- Adjusted documentation and README examples to reflect the new flag name.
- Updated package dependencies for inquirer and types to their latest versions.
- Changed the .gitignore to exclude pnpm-lock.yaml instead of package-lock.json.